### PR TITLE
Update forked module name, paths, and docs to be imported; support for applying multiple options in a TermRendererOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Glamour
+# Why is this forked?
+
+This is hard forked from github.com/charmbracelet/glamour to allow the `gh` maintainers to enhance the use of `glamour` in `gh`, while providing the flexibility for us to share modifications and extensions. It is not intended to be a long-term maintained fork and you should not rely on it.
+
+Once we determine how to address concerns for the project, we will decide what to do next based on how our needs align with the preferences of the maintainers of charmbracelet/glamour.
+
+## Original README with minor tweaks to indicate upstream/fork relationship
 
 <p>
     <img src="https://github.com/user-attachments/assets/23aabf2a-8bd8-4e7b-bb50-993bce32541d" width="300" alt="Glamour Title Treatment"><br>

--- a/examples/artichokes/main.go
+++ b/examples/artichokes/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/charmbracelet/glamour"
+	"github.com/cli/glamour"
 	"github.com/muesli/termenv"
 )
 

--- a/examples/custom_renderer/main.go
+++ b/examples/custom_renderer/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/charmbracelet/glamour"
+	"github.com/cli/glamour"
 )
 
 func main() {

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/charmbracelet/glamour"
+	"github.com/cli/glamour"
 )
 
 func main() {

--- a/examples/stdin-stdout-custom-styles/main.go
+++ b/examples/stdin-stdout-custom-styles/main.go
@@ -14,7 +14,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/charmbracelet/glamour"
+	"github.com/cli/glamour"
 )
 
 const defaultWidth = 80

--- a/examples/stdin-stdout/main.go
+++ b/examples/stdin-stdout/main.go
@@ -14,7 +14,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/charmbracelet/glamour"
+	"github.com/cli/glamour"
 )
 
 const defaultWidth = 80

--- a/glamour.go
+++ b/glamour.go
@@ -15,8 +15,8 @@ import (
 	"github.com/yuin/goldmark/util"
 	"golang.org/x/term"
 
-	"github.com/charmbracelet/glamour/ansi"
-	styles "github.com/charmbracelet/glamour/styles"
+	"github.com/cli/glamour/ansi"
+	styles "github.com/cli/glamour/styles"
 )
 
 const (

--- a/glamour.go
+++ b/glamour.go
@@ -215,6 +215,18 @@ func WithChromaFormatter(formatter string) TermRendererOption {
 	}
 }
 
+// WithOptions sets multiple TermRenderer options within a single TermRendererOption.
+func WithOptions(options ...TermRendererOption) TermRendererOption {
+	return func(tr *TermRenderer) error {
+		for _, o := range options {
+			if err := o(tr); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
 func (tr *TermRenderer) Read(b []byte) (int, error) {
 	return tr.renderBuf.Read(b)
 }

--- a/glamour_test.go
+++ b/glamour_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	styles "github.com/charmbracelet/glamour/styles"
 	"github.com/charmbracelet/x/exp/golden"
+	styles "github.com/cli/glamour/styles"
 )
 
 const markdown = "testdata/readme.markdown.in"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/charmbracelet/glamour
+module github.com/cli/glamour
 
 go 1.21
 

--- a/internal/generate-style-json/main.go
+++ b/internal/generate-style-json/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/charmbracelet/glamour/ansi"
-	styles "github.com/charmbracelet/glamour/styles"
+	"github.com/cli/glamour/ansi"
+	styles "github.com/cli/glamour/styles"
 )
 
 func writeStyleJSON(filename string, styleConfig *ansi.StyleConfig) error {

--- a/styles/dracula.go
+++ b/styles/dracula.go
@@ -1,6 +1,6 @@
 package styles
 
-import "github.com/charmbracelet/glamour/ansi"
+import "github.com/cli/glamour/ansi"
 
 // DraculaStyleConfig is the dracula style.
 var DraculaStyleConfig = ansi.StyleConfig{

--- a/styles/styles.go
+++ b/styles/styles.go
@@ -3,7 +3,7 @@ package styles
 //go:generate go run ../internal/generate-style-json
 
 import (
-	"github.com/charmbracelet/glamour/ansi"
+	"github.com/cli/glamour/ansi"
 )
 
 const (

--- a/styles/tokyo-night.go
+++ b/styles/tokyo-night.go
@@ -1,6 +1,6 @@
 package styles
 
-import "github.com/charmbracelet/glamour/ansi"
+import "github.com/cli/glamour/ansi"
 
 // TokyoNightStyle is the tokyo night style.
 var TokyoNightStyleConfig = ansi.StyleConfig{


### PR DESCRIPTION
This pull request is primarily about getting this fork in a state that it can be imported for `cli/go-gh` experimentation by updating the module name and resulting import paths. As this fork is not meant to be long lived, the README has been updated to dissuade visitors from reusing this in their projects.

Additionally, this pull request introduces the `WithOptions(options ...TermRendererOption) TermRendererOption`, which is helps users apply multiple options while still adhering to the `WithXXXX() TermRendererOption` pattern while not having direct access to rendering code.